### PR TITLE
第3章メソッド：`03_try_over3_3`回答

### DIFF
--- a/03_method/03_try_over3_3.rb
+++ b/03_method/03_try_over3_3.rb
@@ -111,16 +111,22 @@ end
 module TryOver3::TaskHelper
   def self.included(klass)
     klass.define_singleton_method :task do |name, &task_block|
-      new_klass = Class.new do
+      define_singleton_method name.to_sym do
+        puts "start #{Time.now}"
+        block_return = task_block.call
+        puts "finish #{Time.now}"
+        block_return
+      end
+    end
+
+    klass.define_singleton_method :const_missing do |const_name|
+      Class.new do
         define_singleton_method :run do
-          puts "start #{Time.now}"
-          block_return = task_block.call
-          puts "finish #{Time.now}"
-          block_return
+          warn "Warning: #{klass}::#{const_name}.#{__method__.to_s} is deprecated"
+          called_method_name = const_name.downcase
+          klass.send(called_method_name.to_sym)
         end
       end
-      new_klass_name = name.to_s.split("_").map { |w| w[0] = w[0].upcase; w }.join
-      const_set(new_klass_name, new_klass)
     end
   end
 end

--- a/03_method/03_try_over3_3.rb
+++ b/03_method/03_try_over3_3.rb
@@ -120,10 +120,12 @@ module TryOver3::TaskHelper
     end
 
     klass.define_singleton_method :const_missing do |const_name|
+      called_method_name = const_name.downcase
+      return super(const_name) unless respond_to?(called_method_name)
+
       Class.new do
         define_singleton_method :run do
           warn "Warning: #{klass}::#{const_name}.#{__method__.to_s} is deprecated"
-          called_method_name = const_name.downcase
           klass.send(called_method_name.to_sym)
         end
       end

--- a/03_method/03_try_over3_3.rb
+++ b/03_method/03_try_over3_3.rb
@@ -94,7 +94,7 @@ class TryOver3::A4
     end
 
     def const_missing(const_name)
-      return super unless @runners.include?(const_name)
+      return super unless @runners&.include?(const_name)
 
       Class.new do
         define_singleton_method :run do # defではなくdefine_singleton_methodならクロージャを作るのでローカル変数を参照できる

--- a/03_method/test/test_try_over3_3.rb
+++ b/03_method/test/test_try_over3_3.rb
@@ -81,22 +81,22 @@ class TestTryOver03Q1 < Minitest::Test
   end
 
   def test_q5_task_helper_call_method
-    skip unless ENV["CI"]
+    # skip unless ENV["CI"]
     assert_equal("foo", TryOver3::A5Task.foo)
   end
 
   def test_q5_task_helper_not_exists_class
-    skip unless ENV["CI"]
+    # skip unless ENV["CI"]
     refute_includes TryOver3::A5Task.constants, :Foo
   end
 
   def test_q5_task_helper_call_class
-    skip unless ENV["CI"]
+    # skip unless ENV["CI"]
     assert_equal("foo", TryOver3::A5Task::Foo.run)
   end
 
   def test_q5_task_helper_call_class_with_warn
-    skip unless ENV["CI"]
+    # skip unless ENV["CI"]
     _, err = capture_io do
       TryOver3::A5Task::Foo.run
     end


### PR DESCRIPTION
## 感想

- Q4で`const_missing`を思いつくまでに少し時間がかかった。
- (Q4, Q5)：クラス名は定数だからこそ、呼ばれたクラスが存在しない場合に`const_missing`でハンドリングできるのが面白かった。

## 学び

- Rubyのブロックはクロージャなので、ブロックの外で定義された変数をブロック内で参照することができる。（`def`と`define_method`, `define_singleton_method`の違い）
- Kernel クラスのドキュメントを見たのは意外と初めてかもしれません。
  - 標準エラーに出力するための`warn`メソッドを調べる際に確認しました。
  - https://docs.ruby-lang.org/ja/latest/class/Kernel.html
- `const_missing`の`super`を呼び出す際、オーバーライドの仕方によって引数の必要有無が異なるのはなぜ？
  - `def`でオーバーライドしている場合：引数なしでOK
    - https://github.com/mpg-yuma-ito/reading-metaprogramming-ruby/pull/3/files#diff-1ebfd5cf350fd49441d5def17d0ddf68f5e4d636ab3a8791a8743eb4d2b4b68cR96
  - `define_singleton_method`でオーバーライドしている場合：引数が必要（ないとエラーになる）
    - https://github.com/mpg-yuma-ito/reading-metaprogramming-ruby/pull/3/files#diff-1ebfd5cf350fd49441d5def17d0ddf68f5e4d636ab3a8791a8743eb4d2b4b68cR124
